### PR TITLE
fix(openlist): fix permission issue

### DIFF
--- a/template/openlist/index.yaml
+++ b/template/openlist/index.yaml
@@ -66,16 +66,26 @@ spec:
     spec:
       terminationGracePeriodSeconds: 10
       automountServiceAccountToken: false
+      initContainers:
+        - name: fix-permissions
+          image: busybox:1.36
+          command: ['sh', '-c', 'chown -R 1001:1001 /opt/openlist/data && chmod -R 777 /opt/openlist/data']
+          volumeMounts:
+            - name: vn-data
+              mountPath: /opt/openlist/data
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
       containers:
         - name: ${{ defaults.app_name }}
           image: openlistteam/openlist:latest-lite
+          securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
+            runAsNonRoot: true
           env:
             - name: TZ
               value: Asia/Shanghai
-            - name: PUID
-              value: "0"
-            - name: PGID
-              value: "0"
             - name: UMASK
               value: "022"
             - name: OPENLIST_ADMIN_PASSWORD


### PR DESCRIPTION
Because the new version of the image removes the PUID/GUID option and supports rootless operation, the OpenList main program lacks the read and write permission of the configuration file and cannot run
Fix the issue by initializing the settings permissions.

Current Version in App Store:
<img width="1460" height="129" alt="image" src="https://github.com/user-attachments/assets/76ec00c1-c868-44cd-9c45-3da94ab08c9f" />

Fixed Version in this PR:

<img width="967" height="268" alt="image" src="https://github.com/user-attachments/assets/e4ad9d97-b9aa-4869-bfbb-4a608c9a6950" />
